### PR TITLE
Remove the tmp subvolume creation bit from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ After creating the partitions using [fdisk](https://wiki.archlinux.org/index.php
 **IMPORTANT**: I used **-L** option with *mkfs* command in order to create a label for **/** (called **arch**).
 
 ### BTRFS layout
-The only partition formated with BTRFS was /dev/sda3, which contains the whole root system. BTRFS was selected to enable snapshots support in order to avoid any possible problem with Arch updates. Sometimes, I have experimented that certain critical package updates can break the system. If it occurs, it is a good idea to have some snapshot to rollback the entire root filesystem. tmp subvolume has been created in order to avoid the inclusion of temporal files within the snapshots of rootvol. tmp snapshots never will be created, because all the files stored within tmp are temporal. This is the layout defined:
+The only partition formated with BTRFS was /dev/sda3, which contains the whole root system. BTRFS was selected to enable snapshots support in order to avoid any possible problem with Arch updates. Sometimes, I have experimented that certain critical package updates can break the system. If it occurs, it is a good idea to have some snapshot to rollback the entire root filesystem. tmp snapshots never will be created, because all the files stored within tmp are temporal. This is the layout defined:
 
 ```
 sda3 (Volume)


### PR DESCRIPTION
Hi @egara, thank you for making this amazing guide! I followed it and managed to get Arch with BTRFS snapshots working as a total noob!

This bit in README.md seemed outdated because in this [commit](https://github.com/egara/arch-btrfs-installation/commit/adf29cf5f13d3cf1548a733d47cb777641c743dd) you say that there is no need to create a subvolume for `/tmp` anymore, so I removed it.